### PR TITLE
chore: node version v18.12.0 to v22.9.0

### DIFF
--- a/chirimenPanel.html
+++ b/chirimenPanel.html
@@ -23,7 +23,7 @@
     };
     const sleep = (msec) => new Promise((resolve) => setTimeout(resolve, msec));
 
-    var nodeVersion = "v18.12.0";
+    var nodeVersion = "v22.9.0";
     async function setupChirimen() {
       messageDiv.innerHTML = "START CHIRIMEN SETUP";
       var ret;


### PR DESCRIPTION
Node サポート対象バージョンに変更しました。

close #24 

- [Node.js Releases](https://nodejs.org/en/about/previous-releases#nodejs-releases)
- v22.9.0


