### PR TITLE
chore: Node.js を v25.9.0 / linux-arm64-musl に更新

### DIFF
--- a/chirimenPanel.html
+++ b/chirimenPanel.html
@@ -49,7 +49,7 @@
         messageDiv.innerHTML = "NOW GETTING NODE.JS RUNTIME";
         ret = getOutputLines(
           await portWritelnWaitfor(
-            "wget https://unofficial-builds.nodejs.org/download/release/$VERSION/node-$VERSION-$DISTRO.tar.xz",
+            "wget https://unofficial-builds.nodejs.org/download/release/$VERSION/node-$VERSION-linux-arm64-musl.tar.xz",
             cmdPrompt,
             200000,
           ),

--- a/chirimenPanel.html
+++ b/chirimenPanel.html
@@ -23,7 +23,7 @@
     };
     const sleep = (msec) => new Promise((resolve) => setTimeout(resolve, msec));
 
-    var nodeVersion = "v22.22.3";
+    var nodeVersion = "v25.9.0";
     async function setupChirimen() {
       messageDiv.innerHTML = "START CHIRIMEN SETUP";
       var ret;


### PR DESCRIPTION
## Summary
- CHIRIMEN セットアップでインストールする Node.js ランタイムを `v22.22.3` から `v25.9.0` に更新
- ダウンロードするバイナリを `linux-armv6l`（`$DISTRO`）から `linux-arm64-musl` に変更

## Test plan
- [ ] セットアップ未実施の環境で「CHIRIMENセットアップ」を実行し、`node -v` が `v25.9.0` になること
- [ ] ダウンロード URL が `node-v25.9.0-linux-arm64-musl.tar.xz` を指していること
- [ ] 既に Node.js が入っている環境では再インストールせず、既存バージョンが表示されること
- [ ] セットアップ完了後にサンプル取得・常駐アプリ切替が従来どおり動作すること